### PR TITLE
Gradual text render.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,8 @@ fn main() -> amethyst::Result<()> {
         )?
         .with_bundle(InputBundle::<StringBindings>::new().with_bindings_from_file(bindings_path)?)?
         .with_bundle(TransformBundle::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?;
+        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with(billboard::BillboardDisplaySystem, "billboard_display", &[]);
 
     let mut game = Application::new(assets_dir, MyState, game_data)?;
     game.run();


### PR DESCRIPTION
Adds a system to push text to the UI with each tick, gradually advancing
the char count as it goes.

The overall design here seems wrong. Need to get a better handle on how
the ECS works so we can model this as a single entity with 2 components.
Currently it's using a structure where there's one Entity with handles
to two other Entities, each with their own components (which seems wrong).

Additionally, we'll want to be able to control the speed of the text,
which means tracking the delta time between each tick. Currently one
char per tick means different people with different speed CPUs will see
the text appear at different rates. By tracking the wall clock, and
measuring the deltas, we should be able to render the text at a fixed
speed.


![out](https://user-images.githubusercontent.com/301388/83310933-7f518e00-a1c2-11ea-85f0-e8fa1211f042.gif)