### PR TITLE
Move systems to their own module.

### DIFF
--- a/src/billboard.rs
+++ b/src/billboard.rs
@@ -3,10 +3,9 @@
 
 use amethyst::{
     assets::Loader,
-    derive::SystemDesc,
     ecs::{
         prelude::{Component, HashMapStorage},
-        Join, System, SystemData, World, WriteStorage,
+        World,
     },
     prelude::*,
     ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform},
@@ -68,24 +67,4 @@ pub fn init_billboard(world: &mut World) {
         .build();
 
     world.insert(billboard);
-}
-
-/// Updates the display of the billboard text.
-#[derive(SystemDesc)]
-pub struct BillboardDisplaySystem;
-
-impl<'s> System<'s> for BillboardDisplaySystem {
-    type SystemData = (WriteStorage<'s, UiText>, WriteStorage<'s, BillboardData>);
-
-    fn run(&mut self, (mut ui_text, mut billboard): Self::SystemData) {
-        // TODO write out one glyph per <unit of time> instead of per tick.
-        for (text, billboard) in (&mut ui_text, &mut billboard).join() {
-            text.text = billboard.entire_text.chars().take(billboard.head).collect();
-            billboard.head = if billboard.head == billboard.entire_text.len() - 1 {
-                0
-            } else {
-                billboard.head + 1
-            };
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use amethyst::{
 };
 
 mod billboard;
+mod systems;
 
 struct MyState;
 
@@ -44,7 +45,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(InputBundle::<StringBindings>::new().with_bindings_from_file(bindings_path)?)?
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
-        .with(billboard::BillboardDisplaySystem, "billboard_display", &[]);
+        .with(systems::BillboardDisplaySystem, "billboard_display", &[]);
 
     let mut game = Application::new(assets_dir, MyState, game_data)?;
     game.run();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,0 +1,31 @@
+//! ECS Systems.
+//!
+//! In an ECS, *systems* drive change to the "world" (a collection of entities
+//! and resources) in each tick of the game loop.
+
+use crate::billboard::BillboardData;
+use amethyst::{
+    derive::SystemDesc,
+    ecs::{Join, System, SystemData, WriteStorage},
+    ui::UiText,
+};
+
+/// Updates the display of the billboard text.
+#[derive(SystemDesc)]
+pub struct BillboardDisplaySystem;
+
+impl<'s> System<'s> for BillboardDisplaySystem {
+    type SystemData = (WriteStorage<'s, UiText>, WriteStorage<'s, BillboardData>);
+
+    fn run(&mut self, (mut ui_text, mut billboard): Self::SystemData) {
+        // TODO write out one glyph per <unit of time> instead of per tick.
+        for (text, billboard) in (&mut ui_text, &mut billboard).join() {
+            text.text = billboard.entire_text.chars().take(billboard.head).collect();
+            billboard.head = if billboard.head == billboard.entire_text.len() - 1 {
+                0
+            } else {
+                billboard.head + 1
+            };
+        }
+    }
+}


### PR DESCRIPTION
Since systems tend to have a broad *supervisory* view of the game state, it makes some sense to have them all in a module space of their own, as opposed to employing the fractal pattern, pairing systems up with component definitions.

The rationale here is systems may need to leverage components provided by various things coming from numerous areas of the source tree. They also tend to leverage different APIs provided by the ECS compared to modules looking to author new components.