### PR TITLE
Adds Dialogue custom asset, format, loader system w/ pest grammar.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +576,12 @@ name = "bumpalo"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -984,6 +1011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
 name = "fern"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1760,6 +1811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1921,7 @@ checksum = "0abb021006c01b126a936a8dd1351e0720d83995f4fc942d0d426c654f990745"
 dependencies = [
  "alga",
  "approx 0.3.2",
- "generic-array",
+ "generic-array 0.13.2",
  "matrixmultiply",
  "mint",
  "num-complex",
@@ -2076,6 +2133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2255,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.17",
+ "quote 1.0.6",
+ "syn 1.0.27",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "phf"
@@ -3086,9 +3192,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
@@ -3104,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2 1.0.17",
  "quote 1.0.6",
@@ -3153,6 +3259,18 @@ checksum = "2c4ccb6d0d32d277d3ef7dea86203d8210945eb7a45fba89dd445b3595dd0dfc"
 dependencies = [
  "cmake",
  "pkg-config",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3415,6 +3533,8 @@ name = "talkie"
 version = "0.1.0"
 dependencies = [
  "amethyst",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]
@@ -3550,6 +3670,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unic-langid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 amethyst = "0.15.0"
+pest = "2.1.3"
+pest_derive = "2.1.0"
 
 [features]
 default = ["vulkan"]

--- a/assets/dialogue/lipsum.dialogue
+++ b/assets/dialogue/lipsum.dialogue
@@ -1,0 +1,25 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc varius at nisi sit
+amet cursus. Aliquam tempor elementum sapien, eu tincidunt ante rutrum eget.
+Nullam efficitur rhoncus molestie. Interdum et malesuada fames ac ante ipsum
+primis in faucibus. Donec a blandit urna, ut convallis nulla. Aenean quis
+lobortis leo. Pellentesque eget lacus gravida, mattis tortor a, tincidunt nibh.
+Quisque ante justo, eleifend nec tortor sit amet, accumsan scelerisque elit.
+Suspendisse tempor nibh eget congue viverra.
+
+
+Proin laoreet eget nunc consequat pretium. Nam nec purus porttitor, porttitor
+lorem sed, egestas leo. Ut malesuada vehicula eros id elementum. Vestibulum
+laoreet, nulla nec congue convallis, augue felis varius ex, in suscipit neque
+arcu quis massa. Fusce et tristique felis. Donec sed enim faucibus, tincidunt
+sem vitae, volutpat enim. Morbi mattis erat vel lacus rhoncus, vitae auctor nibh
+aliquam. Nam vel gravida eros. Aenean in metus sed nibh malesuada commodo. Cras
+pulvinar elementum nulla ut aliquam.
+
+
+Aenean bibendum, leo eu faucibus elementum, libero orci tempor turpis, non semper
+erat augue a metus. Donec tempor, turpis in auctor facilisis, quam turpis viverra
+tellus, sed pulvinar sapien felis vel tortor. Vestibulum imperdiet fringilla ipsum
+sit amet bibendum. Nullam imperdiet in tellus eu accumsan. Duis ut tempus enim.
+Vivamus sed accumsan erat, et facilisis purus. Vivamus fringilla at risus in
+lobortis. Duis vel magna tortor. Duis sapien libero, sagittis nec turpis vel,
+faucibus volutpat massa.

--- a/src/billboard.rs
+++ b/src/billboard.rs
@@ -1,6 +1,7 @@
 //! The "billboard" is the lower half of the window where dialogue text will
 //! appear.
 
+use crate::dialogue::{DialogueFormat, DialogueHandle};
 use amethyst::{
     assets::Loader,
     ecs::{
@@ -11,31 +12,29 @@ use amethyst::{
     ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform},
 };
 
-#[derive(Default)]
 pub struct BillboardData {
-    /// the full text to display
-    pub entire_text: String,
+    pub dialogue: DialogueHandle,
     /// tracks the current length of *displayed text*.
     pub head: usize,
+    /// tracks which passage we're showing.
+    pub passage: usize,
 }
 
 impl Component for BillboardData {
     type Storage = HashMapStorage<Self>;
 }
 
-static LIPSUM: &str = "\
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
-Duis venenatis rutrum sapien, eu vehicula sapien cursus in. \
-Donec vel pulvinar turpis. Aliquam vestibulum gravida nibh interdum malesuada. \
-Sed rutrum orci nec quam aliquam, id consectetur lorem vestibulum. \
-Praesent cursus justo in orci finibus, non porttitor eros pellentesque. \
-Sed bibendum lectus.\
-";
-
 pub fn init_billboard(world: &mut World) {
     let font = world.read_resource::<Loader>().load(
         "font/CC Accidenz Commons-medium.ttf",
         TtfFormat,
+        (),
+        &world.read_resource(),
+    );
+
+    let dialogue = world.read_resource::<Loader>().load(
+        "dialogue/lipsum.dialogue",
+        DialogueFormat,
         (),
         &world.read_resource(),
     );
@@ -61,8 +60,9 @@ pub fn init_billboard(world: &mut World) {
         .with(xform)
         .with(ui_text)
         .with(BillboardData {
-            entire_text: LIPSUM.to_string(),
+            dialogue,
             head: 0,
+            passage: 0,
         })
         .build();
 

--- a/src/dialogue/dialogue.pest
+++ b/src/dialogue/dialogue.pest
@@ -1,0 +1,14 @@
+WHITESPACE = _{ sep }
+/// Using 2 or more newlines as the separator between passages means each one
+/// will have at least one blank line between it and the previous passage.
+sep = _{ NEWLINE{2,} }
+
+passage = @{
+   (!sep ~ ANY)+
+}
+
+root = {
+    SOI ~
+    passage+
+    ~ EOI
+}

--- a/src/dialogue/mod.rs
+++ b/src/dialogue/mod.rs
@@ -1,0 +1,37 @@
+mod parser;
+
+use amethyst::{
+    assets::{Asset, Format, Handle},
+    ecs::HashMapStorage,
+    error::Error,
+};
+
+/// A sequence of passages
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Dialogue {
+    /// Blocks of text to show, one by one.
+    pub passages: Vec<String>,
+}
+
+/// A handle to a `Dialogue` asset.
+pub type DialogueHandle = Handle<Dialogue>;
+
+impl Asset for Dialogue {
+    const NAME: &'static str = "talkie::dialogue::Dialogue";
+    type Data = Self;
+    type HandleStorage = HashMapStorage<DialogueHandle>;
+}
+
+/// Format for loading from `.dialogue` files.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DialogueFormat;
+
+impl Format<Dialogue> for DialogueFormat {
+    fn name(&self) -> &'static str {
+        "DialogueFormat"
+    }
+
+    fn import_simple(&self, bytes: Vec<u8>) -> Result<Dialogue, Error> {
+        Ok(crate::dialogue::parser::parse(&String::from_utf8(bytes)?)?)
+    }
+}

--- a/src/dialogue/parser.rs
+++ b/src/dialogue/parser.rs
@@ -1,0 +1,64 @@
+use crate::dialogue::Dialogue;
+use amethyst::error::Error;
+use pest::Parser;
+
+#[derive(pest_derive::Parser)]
+#[grammar = "dialogue/dialogue.pest"]
+struct DialogueParser;
+
+pub fn parse(input: &str) -> Result<Dialogue, Error> {
+    let mut ret = Dialogue::default();
+    let mut root = DialogueParser::parse(Rule::root, input)?;
+
+    for token in root.next().unwrap().into_inner() {
+        match token.as_rule() {
+            Rule::passage => ret.passages.push(reformat_passage(token.as_str())),
+            Rule::EOI => (),
+            _ => {
+                unreachable!();
+            }
+        }
+    }
+
+    Ok(ret)
+}
+
+/// Passages are blocks of text separated by 2 or more newlines, but the
+/// newlines inside the passage text itself should be elided.
+/// This is to say, we want to remove the newlines and ensure there is one (one)
+/// space between the thing prior to the newline, and the next non-whitespace
+/// character.
+fn reformat_passage(passage: &str) -> String {
+    passage
+        .lines()
+        .filter_map(|s| {
+            let s = s.trim();
+
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reformat_passage;
+
+    #[test]
+    fn test_reformat_passage() {
+        assert_eq!(
+            "A B C",
+            &reformat_passage(
+                r#"  A
+        B
+        
+            C   
+        "#
+            )
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
+use crate::dialogue::Dialogue;
 use amethyst::{
+    assets::Processor,
     core::transform::TransformBundle,
     input::{InputBundle, StringBindings},
     prelude::*,
@@ -12,6 +14,7 @@ use amethyst::{
 };
 
 mod billboard;
+mod dialogue;
 mod systems;
 
 struct MyState;
@@ -45,7 +48,12 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(InputBundle::<StringBindings>::new().with_bindings_from_file(bindings_path)?)?
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
-        .with(systems::BillboardDisplaySystem, "billboard_display", &[]);
+        .with(Processor::<Dialogue>::new(), "dialogue_processor", &[])
+        .with(
+            systems::BillboardDisplaySystem,
+            "billboard_display",
+            &["dialogue_processor"],
+        );
 
     let mut game = Application::new(assets_dir, MyState, game_data)?;
     game.run();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -4,9 +4,11 @@
 //! and resources) in each tick of the game loop.
 
 use crate::billboard::BillboardData;
+use crate::dialogue::Dialogue;
 use amethyst::{
+    assets::AssetStorage,
     derive::SystemDesc,
-    ecs::{Join, System, SystemData, WriteStorage},
+    ecs::{Join, Read, System, SystemData, WriteStorage},
     ui::UiText,
 };
 
@@ -15,17 +17,45 @@ use amethyst::{
 pub struct BillboardDisplaySystem;
 
 impl<'s> System<'s> for BillboardDisplaySystem {
-    type SystemData = (WriteStorage<'s, UiText>, WriteStorage<'s, BillboardData>);
+    type SystemData = (
+        WriteStorage<'s, UiText>,
+        Read<'s, AssetStorage<Dialogue>>,
+        WriteStorage<'s, BillboardData>,
+    );
 
-    fn run(&mut self, (mut ui_text, mut billboard): Self::SystemData) {
+    fn run(&mut self, (mut ui_text, dialogues, mut billboard): Self::SystemData) {
         // TODO write out one glyph per <unit of time> instead of per tick.
         for (text, billboard) in (&mut ui_text, &mut billboard).join() {
-            text.text = billboard.entire_text.chars().take(billboard.head).collect();
-            billboard.head = if billboard.head == billboard.entire_text.len() - 1 {
-                0
-            } else {
-                billboard.head + 1
-            };
+            if let Some(dialogue) = dialogues.get(&billboard.dialogue) {
+                // XXX: text/passages should not end up empty. If they are, it
+                // there be a problem with the parser.
+                debug_assert!(!dialogue.passages.is_empty());
+                let entire_text = &dialogue.passages[billboard.passage];
+                debug_assert!(!entire_text.is_empty());
+                text.text = entire_text.chars().take(billboard.head).collect();
+
+                let end_of_text = billboard.head == entire_text.len() - 1;
+                let last_passage = billboard.passage == dialogue.passages.len() - 1;
+
+                // Go back to the very start if we're at the end of the last
+                // passage.
+                // If we're at the end of any other passage, reset the head
+                // but advance to the next passage.
+                // Otherwise, reveal another glyph of the current passage.
+                match (end_of_text, last_passage) {
+                    (true, true) => {
+                        billboard.head = 0;
+                        billboard.passage = 0;
+                    }
+                    (true, false) => {
+                        billboard.head = 0;
+                        billboard.passage += 1;
+                    }
+                    (false, _) => {
+                        billboard.head += 1;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This diff has a couple moving pieces. Here's the gist:

- A pest parser reads a file into a list of strings using double (or more) newlines as a separator.
- `Dialogue` is a new asset type, holding a vec of "passages", which are the strings yielded by the parser.
- `DialogueFormat` is used to read bytes from disk and run them through the parser.
- a new `Processor` system was added to handle the async loading of `Dialogue` assets.

Behavioral changes to the program were made in reaction to the new tech:

- The hardcoded lipsum text was replaced with a `Dialogue` asset loaded from file.
- the `BillboardData` component replaced its `entire_text` field with a handle to that asset.
- The `BillboardDisplaySystem` was updated to pull the dialogue asset from storage.
- The system was also updated to cycle through the passages in order.

I had some struggles getting the plumbing settled, but I think we're good to go now.

Most of the work done here was based on instructions in the [Assets chapter](https://book.amethyst.rs/stable/assets.html) of the amethyst book, but there were a number of confusing aspects to the docs.

Lessons learned:

- If your `Asset` and `Asset::Data` types are the same then you **should not** implement the `ProcessableAsset` trait (there's no need to convert from `T` -> `T` since `T` is already a `T`).
- When you want to use a `Handle<T>` to get an asset inside a system, you need to list `AssetStorage<T>` as the resource in your `SystemData`.
- Requests to load custom asset types will *silently do nothing at all* if you do not add a `Processor` system to handle the loading (see the diff in `main.rs` for this).

![cycling through passages](https://user-images.githubusercontent.com/301388/83363533-092e6200-a34f-11ea-8b02-1aa38215b405.gif)

Fixes #7 