### PR TITLE
Add ActionTracker component/system, and use to drive paused field on Billboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,6 +3533,7 @@ name = "talkie"
 version = "0.1.0"
 dependencies = [
  "amethyst",
+ "log",
  "pest",
  "pest_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 amethyst = "0.15.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
+log = "0.4.8"
 
 [features]
 default = ["vulkan"]

--- a/config/bindings.ron
+++ b/config/bindings.ron
@@ -1,4 +1,6 @@
 (
   axes: {},
-  actions: {},
+  actions: {
+    "confirm": [[Key(Space)], [Key(Return)]],
+  },
 )

--- a/src/action_tracker.rs
+++ b/src/action_tracker.rs
@@ -1,0 +1,27 @@
+use amethyst::ecs::prelude::{Component, HashMapStorage};
+
+#[derive(Debug, Clone)]
+pub struct ActionTracker {
+    pub action: &'static str,
+    /// True only when the action is pressed after not being pressed previously.
+    pub press_begin: bool,
+    /// True from the very first press up until the press ends.
+    pub pressed: bool,
+    /// Marks the point where the action was just released.
+    pub press_end: bool,
+}
+
+impl ActionTracker {
+    pub fn new(action: &'static str) -> Self {
+        Self {
+            action,
+            press_begin: false,
+            pressed: false,
+            press_end: false,
+        }
+    }
+}
+
+impl Component for ActionTracker {
+    type Storage = HashMapStorage<Self>;
+}

--- a/src/billboard.rs
+++ b/src/billboard.rs
@@ -18,6 +18,7 @@ pub struct BillboardData {
     pub head: usize,
     /// tracks which passage we're showing.
     pub passage: usize,
+    pub paused: bool,
 }
 
 impl Component for BillboardData {
@@ -63,7 +64,9 @@ pub fn init_billboard(world: &mut World) {
             dialogue,
             head: 0,
             passage: 0,
+            paused: false,
         })
+        .with(crate::action_tracker::ActionTracker::new("confirm"))
         .build();
 
     world.insert(billboard);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use amethyst::{
     utils::application_root_dir,
 };
 
+mod action_tracker;
 mod billboard;
 mod dialogue;
 mod systems;
@@ -49,6 +50,11 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with(Processor::<Dialogue>::new(), "dialogue_processor", &[])
+        .with(
+            systems::ActionTrackerSystem,
+            "action_tracker",
+            &["input_system"],
+        )
         .with(
             systems::BillboardDisplaySystem,
             "billboard_display",


### PR DESCRIPTION
I bolted this all on the existing billboard component and system just to
get a feel for how keybindings worked.

Good: the keybinding system seems great. I've got the space and return
keys both registered to fire the "confirm" action.

Bad: the `InputHandler` can only test to see if an action is *currently*
firing. What we really need is to crack when the action starts firing
and when it stops so we can perform branching based on the in/out
instead of repeatedly pulsing while the thing is pressed.

For the bad, we'll certainly want to track the input state on it's own
component. Maybe I can parameterize it so it can track arbitrary action
names...

----

Okay, 2nd rev cleans this up. 

I kept a `paused` field on the `BillboardData` component, but this is ripe for refactor later. The significant change was to extract the input handling into a separate `ActionTracker` component which can monitor the input states from tick to tick and report on action activation with more detail. For example, it's now possible to know:

- if an action was *just now* activated
- if the action activation is ongoing/sustained
- if the action was previously active but was just released
- or if the action was just not activated at all

With this info I updated the `BillboardDisplaySystem` to flip the `paused` field based on when the action is first pressed.

I have to say, I'm still unsure about how to organize the source tree. Seems like we could cluster all the components stuff in a namespace, and all the systems in their their own namespace.

Should fix #4.