### PR TITLE
Updates dialogue parser to attach a speaker name to a group of passages.

### DIFF
--- a/assets/dialogue/lipsum.dialogue
+++ b/assets/dialogue/lipsum.dialogue
@@ -1,3 +1,5 @@
+::[Richard McClintock]
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc varius at nisi sit
 amet cursus. Aliquam tempor elementum sapien, eu tincidunt ante rutrum eget.
 Nullam efficitur rhoncus molestie. Interdum et malesuada fames ac ante ipsum

--- a/src/assets/dialogue/dialogue.pest
+++ b/src/assets/dialogue/dialogue.pest
@@ -1,14 +1,39 @@
-WHITESPACE = _{ sep }
 /// Using 2 or more newlines as the separator between passages means each one
 /// will have at least one blank line between it and the previous passage.
 sep = _{ NEWLINE{2,} }
 
-passage = @{
-   (!sep ~ ANY)+
+
+non_newline = @{
+  (!NEWLINE ~ ANY)
+}
+
+/// yellow
+name = @{  (!"]" ~ non_newline)+  }
+
+
+name_tag = _{"[" ~ name ~ "]"}
+
+/// orange
+speaker = { "::" ~ name_tag }
+
+passage_group = {
+    sep*
+    ~ speaker
+    ~ sep*
+    ~ passages
+}
+
+/// green
+passage = {
+   (!(sep | passage_group) ~ ANY)+ ~ (sep | EOI)
+}
+
+passages = {
+    (!name_tag ~ passage)+
 }
 
 root = {
     SOI ~
-    passage+
+    passage_group+
     ~ EOI
 }

--- a/src/assets/dialogue/mod.rs
+++ b/src/assets/dialogue/mod.rs
@@ -6,11 +6,17 @@ use amethyst::{
     error::Error,
 };
 
-/// A sequence of passages
+/// A sequence of passages, associated with a speaker.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Dialogue {
+pub struct PassageGroup {
+    pub speaker: String,
     /// Blocks of text to show, one by one.
     pub passages: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Dialogue {
+    pub passage_groups: Vec<PassageGroup>,
 }
 
 /// A handle to a `Dialogue` asset.

--- a/src/components.rs
+++ b/src/components.rs
@@ -41,6 +41,8 @@ pub struct BillboardData {
     pub dialogue: DialogueHandle,
     /// tracks the current length of *displayed text*.
     pub head: usize,
+    /// tracks which passage group we're iterating through.
+    pub passage_group: usize,
     /// tracks which passage we're showing.
     pub passage: usize,
     pub paused: bool,
@@ -88,6 +90,7 @@ pub fn init_billboard(world: &mut World) {
         .with(BillboardData {
             dialogue,
             head: 0,
+            passage_group: 0,
             passage: 0,
             paused: false,
         })


### PR DESCRIPTION
Should fix #12. The name of the speaker is given as a string with each collection of passages.

I'm not entirely happy with the extra level of indirection added to the data structure (I'd prefer everything was flat) but I figure this is stuff that can be improved later. For instance, we might be able to map the speaker names to character enum variants as we flesh this out more.