### PR TITLE
Speaker name display

### DIFF
--- a/assets/billboard.ron
+++ b/assets/billboard.ron
@@ -1,0 +1,53 @@
+#![enable(implicit_some)]
+Container(
+    transform: (
+        id: "billboard_root",
+        x: 0.,
+        y: 0.,
+        z: 0.,
+        anchor: BottomLeft,
+        pivot: BottomLeft,
+    ),
+    children: [
+        Label(
+            transform: (
+                id: "speaker_name",
+                x: 5.,
+                y: 210.,
+                z: 0.,
+                width: 490.,
+                height: 30.,
+                anchor: BottomLeft,
+                pivot: BottomLeft,
+            ),
+            text: (
+                font: File("font/CC Accidenz Commons-medium.ttf", ("TTF", ())),
+                font_size: 16.,
+                color: (.9, .9, 1.0, 1.0),
+                text: "// Speaker Name",
+                line_mode: Wrap,
+                align: BottomLeft,
+            )
+        ),
+        Label(
+            transform: (
+                id: "dialogue_text",
+                x: 5.,
+                y: 5.,
+                z: 0.,
+                width: 490.,
+                height: 200.,
+                anchor: BottomLeft,
+                pivot: BottomLeft,
+            ),
+            text: (
+                font: File("font/CC Accidenz Commons-medium.ttf", ("TTF", ())),
+                font_size: 20.,
+                color: (1.0, 1.0, 1.0, 1.0),
+                text: "dialogue text",
+                line_mode: Wrap,
+                align: TopLeft,
+            )
+        ),
+    ],
+)

--- a/src/components.rs
+++ b/src/components.rs
@@ -6,7 +6,7 @@ use amethyst::{
         World,
     },
     prelude::*,
-    ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform},
+    ui::UiCreator,
 };
 
 #[derive(Debug, Clone)]
@@ -53,13 +53,6 @@ impl Component for BillboardData {
 }
 
 pub fn init_billboard(world: &mut World) {
-    let font = world.read_resource::<Loader>().load(
-        "font/CC Accidenz Commons-medium.ttf",
-        TtfFormat,
-        (),
-        &world.read_resource(),
-    );
-
     let dialogue = world.read_resource::<Loader>().load(
         "dialogue/lipsum.dialogue",
         DialogueFormat,
@@ -67,26 +60,12 @@ pub fn init_billboard(world: &mut World) {
         &world.read_resource(),
     );
 
-    let xform = UiTransform::new(
-        "text".to_string(),
-        Anchor::BottomLeft,
-        Anchor::BottomLeft,
-        5.,
-        5.,
-        1.,
-        // based on a 500x500 window
-        490.,
-        250.,
-    );
-
-    let mut ui_text = UiText::new(font, String::new(), [1., 1., 1., 1.], 24.);
-    ui_text.line_mode = LineMode::Wrap;
-    ui_text.align = Anchor::TopLeft;
+    world.exec(|mut creator: UiCreator<'_>| {
+        creator.create("billboard.ron", ());
+    });
 
     let billboard = world
         .create_entity()
-        .with(xform)
-        .with(ui_text)
         .with(BillboardData {
             dialogue,
             head: 0,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -9,11 +9,11 @@ use crate::components::BillboardData;
 use amethyst::{
     assets::AssetStorage,
     derive::SystemDesc,
-    ecs::{Join, Read, ReadStorage, System, SystemData, Write, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
     ui::{UiFinder, UiText},
 };
-use log::{debug, info};
+use log::debug;
 
 /// Updates the display of the billboard text.
 #[derive(SystemDesc)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -45,33 +45,27 @@ impl<'s> System<'s> for BillboardDisplaySystem {
             if let Some(dialogue) = dialogues.get(&billboard.dialogue) {
                 let group = &dialogue.passage_groups[billboard.passage_group];
 
+                if ui_finder
+                    .find("speaker_name")
+                    .and_then(|e| ui_text.get_mut(e))
+                    .map(|t| t.text = format!("// {}", &group.speaker))
+                    .is_none()
                 {
-                    match ui_finder
-                        .find("speaker_name")
-                        .and_then(|e| ui_text.get_mut(e))
-                    {
-                        Some(t) => {
-                            t.text = format!("// {}", &group.speaker);
-                        }
-                        // bail if we don't have a text display component to write to.
-                        None => return,
-                    }
+                    // bail if we don't have a text display component to write to.
+                    return;
                 }
 
                 // XXX: text/passages should not end up empty. If they are, it
                 // there be a problem with the parser.
                 let entire_text = &group.passages[billboard.passage];
+                if ui_finder
+                    .find("dialogue_text")
+                    .and_then(|e| ui_text.get_mut(e))
+                    .map(|t| t.text = entire_text.chars().take(billboard.head).collect())
+                    .is_none()
                 {
-                    match ui_finder
-                        .find("dialogue_text")
-                        .and_then(|e| ui_text.get_mut(e))
-                    {
-                        Some(t) => {
-                            t.text = entire_text.chars().take(billboard.head).collect();
-                        }
-                        // bail if we don't have a text display component to write to.
-                        None => return,
-                    }
+                    // bail if we don't have a text display component to write to.
+                    return;
                 }
 
                 let end_of_text = billboard.head == entire_text.len() - 1;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -42,22 +42,37 @@ impl<'s> System<'s> for BillboardDisplaySystem {
                 return;
             }
 
-            let text = match ui_finder
-                .find("dialogue_text")
-                .and_then(|e| ui_text.get_mut(e))
-            {
-                Some(t) => t,
-                // bail if we don't have a text display component to write to.
-                None => return,
-            };
-
             if let Some(dialogue) = dialogues.get(&billboard.dialogue) {
                 let group = &dialogue.passage_groups[billboard.passage_group];
-                info!("{} is speaking", &group.speaker);
+
+                {
+                    match ui_finder
+                        .find("speaker_name")
+                        .and_then(|e| ui_text.get_mut(e))
+                    {
+                        Some(t) => {
+                            t.text = format!("// {}", &group.speaker);
+                        }
+                        // bail if we don't have a text display component to write to.
+                        None => return,
+                    }
+                }
+
                 // XXX: text/passages should not end up empty. If they are, it
                 // there be a problem with the parser.
                 let entire_text = &group.passages[billboard.passage];
-                text.text = entire_text.chars().take(billboard.head).collect();
+                {
+                    match ui_finder
+                        .find("dialogue_text")
+                        .and_then(|e| ui_text.get_mut(e))
+                    {
+                        Some(t) => {
+                            t.text = entire_text.chars().take(billboard.head).collect();
+                        }
+                        // bail if we don't have a text display component to write to.
+                        None => return,
+                    }
+                }
 
                 let end_of_text = billboard.head == entire_text.len() - 1;
                 let last_group = billboard.passage_group == dialogue.passage_groups.len() - 1;


### PR DESCRIPTION
Moves the UI component setup into an external file, then adds in a new text widget to display the speaker name.

I tried to manage the layout such that we could move the dialogue text and speaker name together, and while we can do this via the root transform, I was really hoping to figure out a way to position the billboard text and speaker name relative to each other, and the parent. I ended up punting a bit - I set absolute coords on each piece to get this result. Bummer.

Other than the layout woes, one thing I ran into was needing a different way to grab those text widgets in the billboard display system. I ended up having to use `UiFinder` to look them up by ID (a *new-to-me* technique).

Fixes #13