### PR TITLE
Glyph reveals based on time, not ticks. Fixes #6.

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -46,6 +46,11 @@ pub struct BillboardData {
     /// tracks which passage we're showing.
     pub passage: usize,
     pub paused: bool,
+    /// tracks the time since the last glyph was revealed.
+    // XXX: We could default this to 0.0 and not bother with the Option, but
+    //  I thought it might be interesting to be able to know when we're starting
+    //  totally from scratch vs rolling over from a previous iteration.
+    pub secs_since_last_reveal: Option<f32>,
 }
 
 impl Component for BillboardData {
@@ -72,6 +77,7 @@ pub fn init_billboard(world: &mut World) {
             passage_group: 0,
             passage: 0,
             paused: false,
+            secs_since_last_reveal: None,
         })
         .with(ActionTracker::new("confirm"))
         .build();


### PR DESCRIPTION
This diff uses a new field on `BillboardData` to track how long it's
been since the last time glyphs were revealed, and adds the delta time
to it per tick.

When the "since" field has exceeded the glyph reveal period, we loop
through the reveal code once per mod of the time since and the period.

The mod-sized loop is meant to cover cases where the time between ticks
somehow is larger than the period for a single glyph reveal, so as to
"catch up."

The original writeup for #6 described setting this mechanic up using a
new component, but bleh - I'm just going to keep things sloppy for now
and refactor later. It might be prudent to split things up, but I'll
worry about that later.