### PR TITLE
Add conversation branching.

### DIFF
--- a/assets/dialogue/choices.toml
+++ b/assets/dialogue/choices.toml
@@ -1,0 +1,62 @@
+[[section]]
+passages = ["Where you wanna go??"]
+choices = [
+    { label = "As", goto="a" },
+    { label = "Bs", goto="b" },
+    { label = "Cs", goto="c" },
+    { label = "Next" }
+]
+
+[[section]]
+id = "a"
+passages = [
+"AAAAAAAAAAAAAA",
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+"""
+AAAaaaaAAAAAaaaaaaaaAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAaaaaaa
+
+aaaaaaaaaaaaAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAaaaaaaaaaaa
+aaaaaaaaAAAAAAAaaaAAAAA AAAAAAAAAAA
+"""
+]
+choices = [
+    { label = "Bs", goto="b" },
+    { label = "Cs", goto="c" },
+    { label = "Next" }
+]
+
+[[section]]
+id = "b"
+passages = [
+"BBBBBBBBBBBBBB",
+"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+"""
+BBBbbbbBBBBBbbbbbbbbBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBbbbbbb
+
+bbbbbbbbbbbbBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBbbbbbbbbbbb
+bbbbbbbbBBBBBBBbbbBBBBB BBBBBBBBBBB
+"""
+]
+choices = [
+    { label = "As", goto="a" },
+    { label = "Cs", goto="c" },
+    { label = "Next" }
+]
+
+[[section]]
+id = "c"
+passages = [
+"CCCCCCCCCCCCCC",
+"ccccccccccccccccccccccccccccc",
+"""
+CCCccccCCCCCccccccccCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCcccccc
+
+ccccccccccccCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCccccccccccc
+ccccccccCCCCCCCcccCCCCC CCCCCCCCCCC
+"""
+]
+choices = [
+    { label = "As", goto="a" },
+    { label = "Bs", goto="b" },
+    { label = "Next" }
+]

--- a/config/bindings.ron
+++ b/config/bindings.ron
@@ -1,6 +1,6 @@
 (
   axes: {},
   actions: {
-    "confirm": [[Key(Space)], [Key(Return)]],
+    "confirm": [[Key(Space)], [Key(Return)], [Mouse(Left)]],
   },
 )

--- a/src/assets/dialogue/mod.rs
+++ b/src/assets/dialogue/mod.rs
@@ -12,10 +12,10 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct Choice {
     /// The text to display in the menu.
-    label: String,
+    pub label: String,
     /// When  specified, this is used as a section (matched by id) to jump to.
     /// If no goto is listed, the choice simply advances to the next section.
-    goto: Option<String>,
+    pub goto: Option<String>,
 }
 
 /// A sequence of passages, associated with a speaker.
@@ -24,7 +24,7 @@ pub struct PassageGroup {
     /// This optional id is how `Choice`s find the passage group to jump to when
     /// a value for `goto` is set.
     pub id: Option<String>,
-    pub speaker: String,
+    pub speaker: Option<String>,
     /// Blocks of text to show, one by one.
     pub passages: Vec<String>,
     pub choices: Option<Vec<Choice>>,

--- a/src/assets/dialogue/mod.rs
+++ b/src/assets/dialogue/mod.rs
@@ -6,12 +6,28 @@ use amethyst::{
 };
 use serde::Deserialize;
 
+/// Sections that include one or more choices will present a menu to the player
+/// once all the passage text has been shown. The last passage will be displayed
+/// as the prompt for the choices.
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
+pub struct Choice {
+    /// The text to display in the menu.
+    label: String,
+    /// When  specified, this is used as a section (matched by id) to jump to.
+    /// If no goto is listed, the choice simply advances to the next section.
+    goto: Option<String>,
+}
+
 /// A sequence of passages, associated with a speaker.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
 pub struct PassageGroup {
+    /// This optional id is how `Choice`s find the passage group to jump to when
+    /// a value for `goto` is set.
+    pub id: Option<String>,
     pub speaker: String,
     /// Blocks of text to show, one by one.
     pub passages: Vec<String>,
+    pub choices: Option<Vec<Choice>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,4 +1,4 @@
-use crate::assets::dialogue::{Dialogue, DialogueFormat, DialogueHandle};
+use crate::assets::dialogue::{Choice, Dialogue, DialogueFormat, DialogueHandle};
 use crate::components::ActionTracker;
 use crate::utils::calc_glyphs_to_reveal;
 use amethyst::{
@@ -246,8 +246,42 @@ impl SimpleState for PlaybackState {
                 }
             }
 
+            let has_choices = group
+                .choices
+                .as_ref()
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            if last_passage && has_choices {
+                return Trans::Push(Box::new(ChoiceState::new(group.choices.clone().unwrap())));
+            }
+
             Trans::Push(Box::new(PromptState::new("confirm")))
         }
+    }
+}
+
+struct ChoiceState {
+    choices: Vec<Choice>,
+}
+
+impl ChoiceState {
+    pub fn new(choices: Vec<Choice>) -> ChoiceState {
+        ChoiceState { choices }
+    }
+}
+
+impl SimpleState for ChoiceState {
+    fn on_start(&mut self, _data: StateData<'_, GameData<'_, '_>>) {
+        // TODO: build a series of buttons based on `self.choices`
+    }
+
+    fn on_stop(&mut self, _data: StateData<'_, GameData<'_, '_>>) {
+        // TODO: remove the buttons
+    }
+
+    fn fixed_update(&mut self, _data: StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+        println!("{:?}", self.choices);
+        Trans::Pop
     }
 }
 


### PR DESCRIPTION
Conversation branching is now a matter of adding "choices" to a given passage group (aka section).

Choices consist of a text label used when rendering the button, and an optional "id" which corresponds to a new optional `id` field on each passage group.

This implementation uses a new resource named `Goto` to hold a passage id to communicate selections between `PlaybackState` and `ChoiceState`.

The overall flow is like:

- `PlaybackState` renders each passage in a group
  - If the group has `choices` transition to the `ChoiceState` which renders each choice as a button.
  - Otherwise, transition to the `PromptState` as normal.
- `ChoiceState` will `pop` when a button is pressed. The button corresponds to a `Choice` which is used to set value of the `Goto` resource.
- When `PlaybackState` resumes, it checks the resource to see if the value is set, adjusting the active passage group when set. Since it does an `Option::take()` on the passage group id field, this resets for the next iteration of the flow.